### PR TITLE
added public getter for autoupdating bool to mitigate apparent issue where autoUpdating doesn't reliably set false on initialization(?)

### DIFF
--- a/src/ofxAnimatable.h
+++ b/src/ofxAnimatable.h
@@ -205,10 +205,7 @@ class ofxAnimatable{
 	
 		void setAnimFinishedLambda(std::function<void()> func){animEndedLambdaFunc = func;}
 
-		inline bool getIsAutoUpdating()
-		{
-			return autoUpdating;
-		}
+		inline bool getIsAutoUpdating()	{ return autoUpdating; }
 
 	protected:
 

--- a/src/ofxAnimatable.h
+++ b/src/ofxAnimatable.h
@@ -205,6 +205,11 @@ class ofxAnimatable{
 	
 		void setAnimFinishedLambda(std::function<void()> func){animEndedLambdaFunc = func;}
 
+		inline bool getIsAutoUpdating()
+		{
+			return autoUpdating;
+		}
+
 	protected:
 
 		void copyMemberVars(const ofxAnimatable& other);


### PR DESCRIPTION
being able to check the status of autoUpdating let me toggle it on only after checking it. I haven't fully confirmed the cause of the initial issue but checking the status and selectively toggling it seems to let me mitigate it. I'll look further into the actual issue if it is an ofxAnimatable thing and flag it if necessary.